### PR TITLE
fix config and add `sequencer_ip` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ $ cat config.json
 {
 	"SequencerIP": "127.0.0.1",
 	"ListenAddr": "0.0.0.0:8888",
-	"StorePath":  "/root/da/data",
-	"SignerPKPath": "/root/da/pk"
+	"StorePath":  "/root/da/data"
 }
 
 $ go run main.go da start --config config.json

--- a/cmd/da.go
+++ b/cmd/da.go
@@ -31,6 +31,7 @@ var daStartCmd = cli.Command{
 	Usage: "start da server",
 	Flags: []cli.Flag{
 		flag.ConfigFlag,
+		flag.SequencerIPFlag,
 	},
 	Action: daStart,
 }
@@ -55,6 +56,9 @@ func daStart(ctx *cli.Context) (err error) {
 	err = json.Unmarshal(configBytes, &config)
 	if err != nil {
 		return
+	}
+	if ctx.String(flag.SequencerIPFlag.Name) != "" {
+		config.SequencerIP = ctx.String(flag.SequencerIPFlag.Name)
 	}
 
 	fmt.Println("config", string(configBytes))

--- a/cmd/flag/flag.go
+++ b/cmd/flag/flag.go
@@ -19,5 +19,5 @@ var BlobHashFlag = cli.StringFlag{
 
 var SequencerIPFlag = cli.StringFlag{
 	Name:  "sequencer_ip",
-	Usage: "specify sequencer_ip which will override the one in config",
+	Usage: "specify sequencer_ip that overrides the one in config",
 }

--- a/cmd/flag/flag.go
+++ b/cmd/flag/flag.go
@@ -16,3 +16,8 @@ var BlobHashFlag = cli.StringFlag{
 	Name:  "blob_hash",
 	Usage: "specify blob hash flag",
 }
+
+var SequencerIPFlag = cli.StringFlag{
+	Name:  "sequencer_ip",
+	Usage: "specify sequencer_ip which will override the one in config",
+}

--- a/default.json
+++ b/default.json
@@ -1,6 +1,5 @@
 {
-	"SequencerIP": "",
+	"SequencerIP": "127.0.0.1",
 	"ListenAddr": "0.0.0.0:8888",
-	"StorePath":  "/root/da/data",
-	"SignerPKPath": "/root/da/pk"
+	"StorePath": "/root/da/data"
 }


### PR DESCRIPTION
The `SignerPKPath` is replaced with `SequencerIP` in config.

The optional cli `sequencer_ip ` flag has higher priority over the one in config.